### PR TITLE
Audit and tighten docs surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,17 @@ Wizard behavior highlights:
 - preflight checks for required tools and config-path write permissions
 - step-based onboarding flow with explicit review before write
 - safe config writes (temporary file + atomic replace + timestamped backup)
-- stock preset multi-select (`balanced_open_audio`, `device_targets_open_audio`, `craigstreamy_hevc_smart_eng_sub_audio_conform`, `craigstreamy_hevc_selected_english_subtitle_preserve`)
+- stock preset multi-select across the current shipped packs, including:
+  - `balanced_open_audio`
+  - `device_targets_open_audio`
+  - `craigstreamy_hevc_selected_english_subtitle_preserve`
+  - `craigstreamy_hevc_all_sub_preserve`
+  - `craigstreamy_hevc_smart_eng_sub_audio_conform`
+  - `craigstreamy_hevc_all_sub_audio_conform`
+  - `craigstreamy_hevc_smart_eng_sub_subtitle_convert`
+  - `craigstreamy_hevc_smart_eng_sub_subtitle_convert_audio_conform`
+  - `craigstreamy_hevc_smart_eng_sub_aggressive_vmaf`
+  - `craigstreamy_hevc_smart_eng_sub_audio_conform_aggressive_vmaf`
 
 ## Configuration guide
 

--- a/infra/scripts/generate-profile-docs.sh
+++ b/infra/scripts/generate-profile-docs.sh
@@ -57,12 +57,18 @@ parse_behavior_block() {
     return 1
   fi
 
-  behavior="$(sed -n '/^# Behavior:/,/^# Optional env:/p' "$action_file" \
-    | sed '1d;$d' \
-    | sed -E 's/^# ?//' \
-    | sed -E 's/^- +//' \
-    | sed '/^$/d' \
-    || true)"
+  behavior="$(awk '
+    /^# Behavior:/ {in_block=1; next}
+    in_block && /^# Optional env:/ {exit}
+    in_block && /^#/ {
+      line=$0
+      sub(/^# ?/, "", line)
+      sub(/^- /, "", line)
+      if (line != "") print line
+      next
+    }
+    in_block {exit}
+  ' "$action_file" || true)"
 
   if [ -n "$behavior" ]; then
     printf '%s\n' "$behavior"
@@ -212,6 +218,13 @@ write_profile_doc() {
   local first_command_label
   local profile_doc
   local mermaid_variant
+  local subtitle_scope_label
+  local subtitle_handle_label
+  local subtitle_gate_label
+  local yes_stage_label
+  local yes_output_label
+  local no_stage_label
+  local no_output_label
   local typical_input_containers
   local output_intent
   local criteria_codec_display
@@ -261,6 +274,14 @@ write_profile_doc() {
   if printf '%s' "$first_command" | grep -Eq "main_subtitle_preserve_profile.sh|all_sub_preserve_profile.sh|all_sub_audio_conform_profile.sh|smart_eng_sub_audio_conform_profile.sh|smart_eng_sub_audio_conform_aggressive_vmaf_profile.sh|smart_eng_sub_aggressive_vmaf_profile.sh|smart_eng_sub_subtitle_convert_profile.sh|smart_eng_sub_subtitle_convert_audio_conform_profile.sh"; then
     mermaid_variant="subtitle_intent"
   fi
+
+  subtitle_scope_label="smart_eng_sub"
+  subtitle_handle_label="preserve"
+  subtitle_gate_label="smart_eng_sub subtitle selected?"
+  yes_stage_label="Encode HEVC + preserve audio + preserve smart_eng_sub subtitle"
+  yes_output_label="Emit MKV output"
+  no_stage_label="Encode HEVC + preserve audio"
+  no_output_label="Finalize fragmented MP4 + init/moov at start"
 
   typical_input_containers="mkv, mp4, mov, mxf (anything ffmpeg can demux)"
   output_intent="profile-specific output written by selected scenario command"
@@ -365,6 +386,37 @@ write_profile_doc() {
     fi
   fi
 
+  if [ "$is_craigstreamy_all_sub_pack" = "1" ]; then
+    subtitle_scope_label="all_sub_preserve"
+    subtitle_handle_label="preserve"
+    subtitle_gate_label="Any subtitle streams present?"
+    if [ "$is_craigstreamy_audio_conform_pack" = "1" ]; then
+      yes_stage_label="Encode HEVC + conform audio if needed + preserve all subtitle streams"
+      no_stage_label="Encode HEVC + conform audio if needed"
+    else
+      yes_stage_label="Encode HEVC + preserve audio + preserve all subtitle streams"
+      no_stage_label="Encode HEVC + preserve audio"
+    fi
+    yes_output_label="Emit MKV output carrying all subtitle streams"
+    no_output_label="Finalize fragmented MP4 + init/moov at start"
+  elif [ "$is_craigstreamy_subtitle_convert_pack" = "1" ]; then
+    subtitle_scope_label="smart_eng_sub"
+    subtitle_handle_label="subtitle_convert"
+    subtitle_gate_label="Selected subtitle is text-convertible and MP4 remains viable?"
+    if [ "$is_craigstreamy_audio_conform_pack" = "1" ]; then
+      yes_stage_label="Encode HEVC + conform audio if needed + convert selected subtitle to mov_text"
+      no_stage_label="Encode HEVC + conform audio if needed + preserve selected subtitle by explicit fallback"
+    else
+      yes_stage_label="Encode HEVC + preserve audio + convert selected subtitle to mov_text"
+      no_stage_label="Encode HEVC + preserve audio + apply bitmap/fallback subtitle policy"
+    fi
+    yes_output_label="Emit MP4 output with converted subtitle text"
+    no_output_label="Emit explicit fallback output (usually MKV preserve or fail)"
+  elif [ "$is_craigstreamy_audio_conform_pack" = "1" ]; then
+    yes_stage_label="Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle"
+    no_stage_label="Encode HEVC + conform audio if needed"
+  fi
+
   criteria_line="
 | Field | Value |
 | --- | --- |
@@ -420,6 +472,9 @@ write_profile_doc() {
 
     if [ "$is_craigstreamy_subtitle_pack" = "1" ]; then
       printf '## Intent\n\n'
+      if [ "$pack" = "craigstreamy-hevc-selected-english-subtitle-preserve" ]; then
+        printf 'Compatibility note: this pack is the canonical replacement for the older `netflixy_main_subtitle_intent` family, but its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.\n\n'
+      fi
       if [ "$is_craigstreamy_subtitle_convert_pack" = "1" ]; then
         printf 'This profile converts candidates into streaming-friendly HEVC outputs while keeping the `smart_eng_sub` subtitle selection heuristic and converting selected text subtitles into delivery-friendly text form when the final container remains MP4-friendly.\n\n'
       elif [ "$is_craigstreamy_all_sub_pack" = "1" ]; then
@@ -541,28 +596,26 @@ write_profile_doc() {
 
     printf '## Flow\n\n'
     if [ "$mermaid_variant" = "subtitle_intent" ]; then
-      cat <<'MERMAID'
-```mermaid
-flowchart LR
-  classDef gate fill:#fff7ed,stroke:#f59e0b,color:#7c2d12,stroke-width:1.5px;
-  classDef stage fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e,stroke-width:1.2px;
-  classDef output fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:1.2px;
-  classDef skip fill:#f3f4f6,stroke:#6b7280,color:#1f2937,stroke-width:1.2px;
-
-  A[Input candidate: mkv / mp4 / mov / mxf]:::stage --> B[Probe codec bits color resolution]:::stage
-  B --> C{Matches profile criteria envelope?}:::gate
-  C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
-  C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
-  E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
-```
-MERMAID
+      printf '```mermaid\n'
+      printf 'flowchart LR\n'
+      printf '  classDef gate fill:#fff7ed,stroke:#f59e0b,color:#7c2d12,stroke-width:1.5px;\n'
+      printf '  classDef stage fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e,stroke-width:1.2px;\n'
+      printf '  classDef output fill:#dcfce7,stroke:#16a34a,color:#14532d,stroke-width:1.2px;\n'
+      printf '  classDef skip fill:#f3f4f6,stroke:#6b7280,color:#1f2937,stroke-width:1.2px;\n'
+      printf '\n'
+      printf '  A[Input candidate: mkv / mp4 / mov / mxf]:::stage --> B[Probe codec bits color resolution]:::stage\n'
+      printf '  B --> C{Matches profile criteria envelope?}:::gate\n'
+      printf '  C -->|No| Z[Handled by other profile or guardrail skipped]:::skip\n'
+      printf '  C -->|Yes| D{Evaluate scenarios in order}:::gate\n'
+      printf '  D --> E[Execute subtitle-policy action]:::stage\n'
+      printf '  E --> P[Optional lane-specific pre-processing]:::stage\n'
+      printf '  P --> F{%s}:::gate\n' "$(mermaid_text "$subtitle_gate_label")"
+      printf '  F -->|Yes| G[%s]:::stage\n' "$(mermaid_text "$yes_stage_label")"
+      printf '  G --> H[%s]:::output\n' "$(mermaid_text "$yes_output_label")"
+      printf '  F -->|No| I[%s]:::stage\n' "$(mermaid_text "$no_stage_label")"
+      printf '  I --> J[%s]:::stage\n' "$(mermaid_text "$no_output_label")"
+      printf '  J --> K[Emit final profile artifact]:::output\n'
+      printf '```\n'
     else
       first_scenario_safe="$(mermaid_text "$first_scenario")"
       first_command_safe="$(mermaid_text "$first_command_label")"
@@ -731,6 +784,7 @@ done < <(find "$PRESETS_DIR" -type f -name 'vfo_config.preset.conf' | sort)
 {
   printf '# Stock Profile Info Sheets\n\n'
   printf 'These pages are generated from stock preset files and linked action scripts.\n\n'
+  printf 'Compatibility note: the canonical pack `craigstreamy_hevc_selected_english_subtitle_preserve` still emits generated profile sheets using the legacy `netflixy_preserve_audio_main_subtitle_intent_*` profile ids for compatibility.\n\n'
   printf 'Regenerate with:\n\n'
   printf '```bash\n'
   printf 'bash infra/scripts/generate-profile-docs.sh\n'
@@ -755,6 +809,7 @@ done < <(find "$PRESETS_DIR" -type f -name 'vfo_config.preset.conf' | sort)
   printf '\n## Notes\n\n'
   printf -- '- This matrix reflects stock presets, not every custom profile a user may define.\n'
   printf -- '- `craigstreamy_hevc_selected_english_subtitle_preserve` remains the preserve-audio subtitle-intent pack.\n'
+  printf -- '- Its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.\n'
   printf -- '- `craigstreamy_hevc_smart_eng_sub_aggressive_vmaf` adds video-only aggressive-VMAF behavior on top of the preserve-audio subtitle-intent family.\n'
   printf -- '- `craigstreamy_hevc_smart_eng_sub_audio_conform` adds DTS/PCM delivery-conform behavior on top of the subtitle-intent family.\n'
   printf -- '- `craigstreamy_hevc_all_sub_audio_conform` and `craigstreamy_hevc_smart_eng_sub_subtitle_convert_audio_conform` complete the first audio-conform subtitle matrix.\n'

--- a/platform/docs-site/docs/deployment-modes.md
+++ b/platform/docs-site/docs/deployment-modes.md
@@ -22,7 +22,7 @@
 
 - `base`: `ffmpeg`, `ffprobe`, `mkvmerge`
 - `dv`: `dovi_tool` (and related DV utilities where needed)
-- `quality`: PSNR/SSIM via ffmpeg filters, optional VMAF via `libvmaf` for post-profile scoring today and future `aggressive_vmaf` quality mode
+- `quality`: PSNR/SSIM via ffmpeg filters, optional VMAF via `libvmaf` for post-profile scoring and the shipped bounded `aggressive_vmaf` quality mode
 
 ## Why Not Bundle Everything by Default?
 

--- a/platform/docs-site/docs/index.md
+++ b/platform/docs-site/docs/index.md
@@ -25,7 +25,7 @@ This site is built to answer three practical questions quickly:
 2. Read [Flow Levels](flow-levels.md) for interactive executive/operator/engine React Flow visuals.
 3. Read [Profile Pack Strategy](profile-pack-strategy.md) to understand how fixed pack names, subtitle policies, audio policies, and quality modes fit together.
 4. Read [Subtitle Policy](subtitle-policy-taxonomy.md) to understand `smart_eng_sub`, `all_sub_preserve`, and `subtitle_convert`.
-5. Read [Quality Modes](quality-mode-taxonomy.md) to understand `standard` and future `aggressive_vmaf` behavior.
+5. Read [Quality Modes](quality-mode-taxonomy.md) to understand `standard` and the shipped bounded `aggressive_vmaf` mode.
 6. Check [Capability Matrix](profile-capability-matrix.md) to see what each stock profile targets.
 7. Open [Profile Info Sheets](profiles/index.md) for deep behavior details per profile.
 8. Review [Latest E2E Toolchain Report](e2e-toolchain-latest.md) for the dependency versions used in recent CI verification.

--- a/platform/docs-site/docs/profile-capability-matrix.md
+++ b/platform/docs-site/docs/profile-capability-matrix.md
@@ -45,6 +45,7 @@ Generated from stock preset criteria (`PROFILE=` blocks).
 
 - This matrix reflects stock presets, not every custom profile a user may define.
 - `craigstreamy_hevc_selected_english_subtitle_preserve` remains the preserve-audio subtitle-intent pack.
+- Its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.
 - `craigstreamy_hevc_smart_eng_sub_aggressive_vmaf` adds video-only aggressive-VMAF behavior on top of the preserve-audio subtitle-intent family.
 - `craigstreamy_hevc_smart_eng_sub_audio_conform` adds DTS/PCM delivery-conform behavior on top of the subtitle-intent family.
 - `craigstreamy_hevc_all_sub_audio_conform` and `craigstreamy_hevc_smart_eng_sub_subtitle_convert_audio_conform` complete the first audio-conform subtitle matrix.

--- a/platform/docs-site/docs/profile-packs.md
+++ b/platform/docs-site/docs/profile-packs.md
@@ -149,6 +149,7 @@ Included active profiles:
 - `netflixy_preserve_audio_main_subtitle_intent_4k`
 - `netflixy_preserve_audio_main_subtitle_intent_1080p`
 - `netflixy_preserve_audio_main_subtitle_intent_legacy_subhd`
+- these legacy profile ids remain in place as compatibility aliases under the canonical `craigstreamy` pack name
 - details + flow: [Craigstreamy HEVC Selected English Subtitle Preserve Pack](profiles/packs/craigstreamy-hevc-selected-english-subtitle-preserve.md)
 
 ## device_targets_open_audio

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-1080p.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-4k.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-audio-conform-legacy-subhd.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-1080p.md
@@ -58,9 +58,6 @@ Action summary from `transcode_hevc_1080_all_sub_preserve_profile.sh`:
 - sets subtitle selection scope to `all_sub_preserve`
 - keeps subtitle mode at `preserve`
 - preserves audio streams with stream copy
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="all_sub_preserve"
-- export VFO_SUBTITLE_MODE="preserve"
 
 ## Starting Inputs And Expected Outputs
 
@@ -86,14 +83,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-4k.md
@@ -58,9 +58,6 @@ Action summary from `transcode_hevc_4k_all_sub_preserve_profile.sh`:
 - sets subtitle selection scope to `all_sub_preserve`
 - keeps subtitle mode at `preserve`
 - preserves audio streams with stream copy
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="all_sub_preserve"
-- export VFO_SUBTITLE_MODE="preserve"
 
 ## Starting Inputs And Expected Outputs
 
@@ -86,14 +83,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-all-sub-preserve-legacy-subhd.md
@@ -58,9 +58,6 @@ Action summary from `transcode_hevc_legacy_all_sub_preserve_profile.sh`:
 - sets subtitle selection scope to `all_sub_preserve`
 - keeps subtitle mode at `preserve`
 - preserves audio streams with stream copy
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="all_sub_preserve"
-- export VFO_SUBTITLE_MODE="preserve"
 
 ## Starting Inputs And Expected Outputs
 
@@ -86,14 +83,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
+  P --> F{Any subtitle streams present?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + preserve all subtitle streams]:::stage
+  G --> H[Emit MKV output carrying all subtitle streams]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-1080p.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-4k.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-aggressive-vmaf-legacy-subhd.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-1080p.md
@@ -119,14 +119,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-4k.md
@@ -136,14 +136,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-1080p.md
@@ -78,14 +78,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-4k.md
@@ -78,14 +78,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf-legacy-subhd.md
@@ -78,14 +78,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-audio-conform-legacy-subhd.md
@@ -131,14 +131,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
+  F -->|Yes| G[Encode HEVC + conform audio if needed + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
+  F -->|No| I[Encode HEVC + conform audio if needed]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-1080p.md
@@ -59,9 +59,6 @@ Action summary from `transcode_hevc_1080_smart_eng_sub_subtitle_convert_profile.
 - changes subtitle mode to `subtitle_convert`
 - preserves audio streams with stream copy
 - fails on bitmap subtitle conversion unless `VFO_SUBTITLE_CONVERT_BITMAP_POLICY=preserve_mkv`
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="smart_eng_sub"
-- export VFO_SUBTITLE_MODE="subtitle_convert"
 
 ## Starting Inputs And Expected Outputs
 
@@ -87,14 +84,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + preserve audio + apply bitmap/fallback subtitle policy]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-4k.md
@@ -59,9 +59,6 @@ Action summary from `transcode_hevc_4k_smart_eng_sub_subtitle_convert_profile.sh
 - changes subtitle mode to `subtitle_convert`
 - preserves audio streams with stream copy
 - fails on bitmap subtitle conversion unless `VFO_SUBTITLE_CONVERT_BITMAP_POLICY=preserve_mkv`
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="smart_eng_sub"
-- export VFO_SUBTITLE_MODE="subtitle_convert"
 
 ## Starting Inputs And Expected Outputs
 
@@ -87,14 +84,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + preserve audio + apply bitmap/fallback subtitle policy]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-1080p.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed + preserve selected subtitle by explicit fallback]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-4k.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-4k.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed + preserve selected subtitle by explicit fallback]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform-legacy-subhd.md
@@ -77,14 +77,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + conform audio if needed + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + conform audio if needed + preserve selected subtitle by explicit fallback]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/craigstreamy-hevc-smart-eng-sub-subtitle-convert-legacy-subhd.md
@@ -59,9 +59,6 @@ Action summary from `transcode_hevc_legacy_smart_eng_sub_subtitle_convert_profil
 - changes subtitle mode to `subtitle_convert`
 - preserves audio streams with stream copy
 - fails on bitmap subtitle conversion unless `VFO_SUBTITLE_CONVERT_BITMAP_POLICY=preserve_mkv`
-- SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-- export VFO_SUBTITLE_SELECTION_SCOPE="smart_eng_sub"
-- export VFO_SUBTITLE_MODE="subtitle_convert"
 
 ## Starting Inputs And Expected Outputs
 
@@ -87,14 +84,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
-  P --> F{smart_eng_sub subtitle selected?}:::gate
-  F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
-  G --> H[Emit MKV output]:::output
-  F -->|No| I[Encode HEVC + preserve audio]:::stage
-  I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  P --> F{Selected subtitle is text-convertible and MP4 remains viable?}:::gate
+  F -->|Yes| G[Encode HEVC + preserve audio + convert selected subtitle to mov_text]:::stage
+  G --> H[Emit MP4 output with converted subtitle text]:::output
+  F -->|No| I[Encode HEVC + preserve audio + apply bitmap/fallback subtitle policy]:::stage
+  I --> J[Emit explicit fallback output (usually MKV preserve or fail)]:::stage
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-1080p.md
+++ b/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-1080p.md
@@ -21,6 +21,8 @@ This profile is considered e2e-verified when its mapped suites pass in CI.
 
 ## Intent
 
+Compatibility note: this pack is the canonical replacement for the older `netflixy_main_subtitle_intent` family, but its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.
+
 This profile converts candidates into streaming-friendly HEVC outputs while preserving the `smart_eng_sub + preserve` subtitle policy where feasible.
 
 ## What It Optimizes For
@@ -108,14 +110,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-4k.md
+++ b/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-4k.md
@@ -25,6 +25,8 @@ This profile is considered e2e-verified when its mapped suites pass in CI.
 
 ## Intent
 
+Compatibility note: this pack is the canonical replacement for the older `netflixy_main_subtitle_intent` family, but its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.
+
 This profile converts candidates into streaming-friendly HEVC outputs while preserving the `smart_eng_sub + preserve` subtitle policy where feasible.
 
 ## What It Optimizes For
@@ -125,14 +127,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-legacy-subhd.md
+++ b/platform/docs-site/docs/profiles/generated/netflixy-preserve-audio-main-subtitle-intent-legacy-subhd.md
@@ -21,6 +21,8 @@ This profile is considered e2e-verified when its mapped suites pass in CI.
 
 ## Intent
 
+Compatibility note: this pack is the canonical replacement for the older `netflixy_main_subtitle_intent` family, but its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility.
+
 This profile converts candidates into streaming-friendly HEVC outputs while preserving the `smart_eng_sub + preserve` subtitle policy where feasible.
 
 ## What It Optimizes For
@@ -120,14 +122,14 @@ flowchart LR
   B --> C{Matches profile criteria envelope?}:::gate
   C -->|No| Z[Handled by other profile or guardrail skipped]:::skip
   C -->|Yes| D{Evaluate scenarios in order}:::gate
-  D --> E[Execute subtitle-intent action]:::stage
+  D --> E[Execute subtitle-policy action]:::stage
   E --> P[Optional lane-specific pre-processing]:::stage
   P --> F{smart_eng_sub subtitle selected?}:::gate
   F -->|Yes| G[Encode HEVC + preserve audio + preserve smart_eng_sub subtitle]:::stage
   G --> H[Emit MKV output]:::output
   F -->|No| I[Encode HEVC + preserve audio]:::stage
   I --> J[Finalize fragmented MP4 + init/moov at start]:::stage
-  J --> K[Emit MP4 output]:::output
+  J --> K[Emit final profile artifact]:::output
 ```
 
 ## What This Profile Does Not Do

--- a/platform/docs-site/docs/profiles/index.md
+++ b/platform/docs-site/docs/profiles/index.md
@@ -2,6 +2,8 @@
 
 These pages are generated from stock preset files and linked action scripts.
 
+Compatibility note: the canonical pack `craigstreamy_hevc_selected_english_subtitle_preserve` still emits generated profile sheets using the legacy `netflixy_preserve_audio_main_subtitle_intent_*` profile ids for compatibility.
+
 Regenerate with:
 
 ```bash

--- a/platform/docs-site/docs/profiles/packs/craigstreamy-hevc-selected-english-subtitle-preserve.md
+++ b/platform/docs-site/docs/profiles/packs/craigstreamy-hevc-selected-english-subtitle-preserve.md
@@ -17,7 +17,13 @@ Canonical subtitle policy for this pack:
 - selection scope: `smart_eng_sub`
 - handling mode: `preserve`
 
-This pack keeps its existing legacy-facing name, but its subtitle behavior should now be understood through the shared [Subtitle Policy](../../subtitle-policy-taxonomy.md) taxonomy.
+This pack keeps its existing legacy-facing profile ids, but its subtitle behavior should now be understood through the shared [Subtitle Policy](../../subtitle-policy-taxonomy.md) taxonomy.
+
+Compatibility note:
+
+- the pack name is now canonical `craigstreamy`
+- the generated profile ids inside this pack still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names
+- that legacy profile-id surface remains intentional for compatibility
 
 ## What It Optimizes For
 

--- a/services/vfo/presets/README.md
+++ b/services/vfo/presets/README.md
@@ -6,14 +6,19 @@ Current preset packs:
 
 - `balanced_open_audio/`
 - `device_targets_open_audio/`
-- `craigstreamy-hevc-all-sub-audio-conform/`
 - `craigstreamy-hevc-all-sub-preserve/`
-- `craigstreamy-hevc-smart-eng-sub-aggressive-vmaf/`
-- `craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf/`
-- `craigstreamy-hevc-selected-english-subtitle-preserve/`
+- `craigstreamy-hevc-all-sub-audio-conform/`
 - `craigstreamy-hevc-smart-eng-sub-audio-conform/`
 - `craigstreamy-hevc-smart-eng-sub-subtitle-convert/`
 - `craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform/`
+- `craigstreamy-hevc-smart-eng-sub-aggressive-vmaf/`
+- `craigstreamy-hevc-smart-eng-sub-audio-conform-aggressive-vmaf/`
+- `craigstreamy-hevc-selected-english-subtitle-preserve/`
+
+Compatibility note:
+
+- `craigstreamy-hevc-selected-english-subtitle-preserve/` is the canonical pack name
+- its generated profile ids still use the legacy `netflixy_preserve_audio_main_subtitle_intent_*` names for compatibility
 
 Canonical subtitle policy vocabulary now lives in `platform/docs-site/docs/subtitle-policy-taxonomy.md`.
 Quality mode vocabulary now lives in `platform/docs-site/docs/quality-mode-taxonomy.md`.


### PR DESCRIPTION
## Summary
- audit the docs surface against the actual shipped pack matrix and fix stale high-level summaries
- tighten the profile-doc generator so generated flows and action summaries reflect `all_sub_preserve`, `subtitle_convert`, and legacy craigstreamy alias behavior correctly
- regenerate the profile sheets, profiles index, and capability matrix from the corrected source-of-truth generator

## Verification
- `bash -n infra/scripts/generate-profile-docs.sh`
- `bash infra/scripts/generate-profile-docs.sh`
- local markdown link sanity check across `platform/docs-site/docs` (`TOTAL 0` missing relative links)

## Notes
- `mkdocs` is not installed in this environment, so I could not run a full local site build here.
