### PR TITLE
Add profile pack YAML examples

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - Profile Pack Strategy: profile-pack-strategy.md
   - Subtitle Policy: subtitle-policy-taxonomy.md
   - Quality Modes: quality-mode-taxonomy.md
+  - Profile Pack YAML Examples: profile-pack-yaml-examples.md
   - Capability Matrix: profile-capability-matrix.md
   - Latest E2E Toolchain: e2e-toolchain-latest.md
   - Observability Contract: observability-contract.md

--- a/platform/docs-site/docs/index.md
+++ b/platform/docs-site/docs/index.md
@@ -32,6 +32,7 @@ This site is built to answer three practical questions quickly:
 9. Read [Observability Contract](observability-contract.md) for the event model that feeds the browser app, logs, metrics, and traces.
 10. Read [Deployment Modes](deployment-modes.md) to choose between local native, desktop-managed, and container lanes.
 11. Open [Demo Pack Replay](vfo-web-app/) for the shareable browser view of the desktop wireframe.
+5. Read [Profile Pack YAML Examples](profile-pack-yaml-examples.md) for the declarative draft shape.
 
 ## Install and Verify
 

--- a/platform/docs-site/docs/profile-pack-yaml-examples.md
+++ b/platform/docs-site/docs/profile-pack-yaml-examples.md
@@ -1,0 +1,309 @@
+# Profile Pack YAML Examples
+
+This page sketches a pack-per-file declarative shape using the stock packs VFO
+already ships.
+
+It is a discussion draft, not the runtime contract yet. Today, `vfo_config.conf`
+and the current stock preset blocks remain the source of truth for execution.
+The goal here is to show how a future planner/compiler could express the same
+pack intent in a cleaner declarative form.
+
+## Why This Shape
+
+- one YAML file per stock pack keeps the pack easy to review
+- each pack can list the concrete devices it covers
+- the YAML can capture intent before the executor details are chosen
+- current `vfo_config.conf` behavior can still be generated or bridged from it
+
+## Balanced Open Audio
+
+This example mirrors the current balanced starter pack:
+
+- `balanced_4k_open_audio`
+- `balanced_1080_open_audio`
+
+```yaml
+pack:
+  id: balanced_open_audio
+  title: Balanced Open Audio
+  source: stock_pack
+  intent:
+    audio_policy: preserve
+    subtitle_policy: preserve
+    quality_mode: standard
+    container_preference: mp4
+  profiles:
+    - id: balanced_4k_open_audio
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_profile
+        fallback: transcode_hevc_4k_profile
+    - id: balanced_1080_open_audio
+      target:
+        codec: h264
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 1920
+            height: 1080
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_1080_profile
+        fallback: transcode_hevc_1080_profile
+```
+
+## Device Targets Open Audio
+
+This example keeps the family pack explicit while still listing the concrete
+device baselines that each lane is meant to cover.
+
+```yaml
+pack:
+  id: device_targets_open_audio
+  title: Device Targets Open Audio
+  source: stock_pack
+  intent:
+    audio_policy: preserve
+    subtitle_policy: preserve
+    quality_mode: standard
+    container_preference: fmp4
+  profiles:
+    - id: roku_family_hd_open_audio
+      covered_devices:
+        - roku_express_1080
+      target:
+        codec: h264
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 1920
+            height: 1080
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_h264_1080_hdr_to_sdr_profile
+        fallback: transcode_h264_1080_hdr_to_sdr_profile
+    - id: roku_family_4k_open_audio
+      covered_devices:
+        - roku_4k
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_profile
+        fallback: transcode_hevc_4k_profile
+    - id: fire_tv_family_hd_open_audio
+      covered_devices:
+        - fire_tv_stick_lite_1080
+      target:
+        codec: h264
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 1920
+            height: 1080
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_h264_1080_hdr_to_sdr_profile
+        fallback: transcode_h264_1080_hdr_to_sdr_profile
+    - id: fire_tv_family_4k_open_audio
+      covered_devices:
+        - fire_tv_stick_4k
+        - fire_tv_stick_4k_max
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_profile
+        fallback: transcode_hevc_4k_profile
+    - id: chromecast_google_tv_hd_open_audio
+      covered_devices:
+        - chromecast_google_tv_hd
+      target:
+        codec: h264
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 1920
+            height: 1080
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_h264_1080_hdr_to_sdr_profile
+        fallback: transcode_h264_1080_hdr_to_sdr_profile
+    - id: chromecast_google_tv_4k_open_audio
+      covered_devices:
+        - chromecast_google_tv_4k
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_profile
+        fallback: transcode_hevc_4k_profile
+    - id: apple_tv_hd_open_audio
+      covered_devices:
+        - apple_tv_hd
+      target:
+        codec: h264
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 1920
+            height: 1080
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_h264_1080_hdr_to_sdr_profile
+        fallback: transcode_h264_1080_hdr_to_sdr_profile
+    - id: apple_tv_4k_open_audio
+      covered_devices:
+        - apple_tv_4k
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_profile
+        fallback: transcode_hevc_4k_profile
+    - id: fire_tv_stick_4k_dv_open_audio
+      covered_devices:
+        - fire_tv_stick_4k_dv
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 352
+            height: 240
+          max:
+            width: 3840
+            height: 2160
+      runtime_bridge:
+        exact_match: copy
+        res_too_high: transcode_hevc_4k_dv_profile
+        fallback: transcode_hevc_4k_dv_profile
+```
+
+## Craigstreamy HEVC Selected English Subtitle Preserve
+
+This example keeps the current intent-driven HEVC pack visible, including the
+legacy compatibility bridge that the runtime still understands today.
+
+```yaml
+pack:
+  id: craigstreamy_hevc_selected_english_subtitle_preserve
+  title: Craigstreamy HEVC Selected English Subtitle Preserve
+  source: stock_pack
+  intent:
+    audio_policy: preserve
+    subtitle_policy: smart_eng_sub
+    quality_mode: standard
+    container_preference:
+      preserve_with_subtitles: mkv
+      otherwise: fmp4
+  profiles:
+    - id: craigstreamy_hevc_selected_english_subtitle_preserve_4k
+      runtime_profile_id: netflixy_preserve_audio_main_subtitle_intent_4k
+      target:
+        codec: hevc
+        color_space: any
+        resolution:
+          min:
+            width: 1920
+            height: 1080
+          max:
+            width: 3840
+            height: 2160
+      notes:
+        - preserve subtitles when the selected English subtitle is intent-oriented
+        - emit mkv when subtitle intent applies
+    - id: craigstreamy_hevc_selected_english_subtitle_preserve_1080p
+      runtime_profile_id: netflixy_preserve_audio_main_subtitle_intent_1080p
+      target:
+        codec: hevc
+        color_space: bt709
+        resolution:
+          min:
+            width: 1280
+            height: 720
+          max:
+            width: 1920
+            height: 1080
+      notes:
+        - sdr-only 1080p lane
+    - id: craigstreamy_hevc_selected_english_subtitle_preserve_legacy_subhd
+      runtime_profile_id: netflixy_preserve_audio_main_subtitle_intent_legacy_subhd
+      target:
+        codec: hevc
+        color_space: any
+        resolution:
+          min:
+            width: 320
+            height: 240
+          max:
+            width: 1279
+            height: 719
+      notes:
+        - legacy sub-hd lane with broad codec and color intake
+```
+
+## What This Would Buy Us
+
+- one pack file could describe intent, lane coverage, and fallback shape
+- docs could be generated from the same pack source
+- the current stock `vfo_config.conf` blocks could become generated or bridged
+- the wizard could still surface the same stock packs, but from a more declarative model
+

--- a/platform/docs-site/docs/profile-packs.md
+++ b/platform/docs-site/docs/profile-packs.md
@@ -43,6 +43,9 @@ Quality behavior is also orthogonal to pack names:
 
 Read [Quality Modes](quality-mode-taxonomy.md) for the quality-mode model and the current implementation boundary.
 
+If you want to see how these stock packs could be expressed declaratively, read
+[Profile Pack YAML Examples](profile-pack-yaml-examples.md).
+
 ## Selection Model
 
 Use this shorthand:
@@ -221,12 +224,9 @@ Pack id: `craigstreamy_hevc_smart_eng_sub_subtitle_convert_audio_conform`
 
 Focus:
 
-- practical HEVC bitrate reduction approach
 - subtitle policy: `smart_eng_sub` + `subtitle_convert`
-- preserve AAC and Dolby-family audio when already acceptable
-- conform DTS-family and PCM-family audio when needed
-- convert selected text subtitles into delivery-friendly text when MP4 remains viable
-- preserve selected subtitles in MKV rather than pretending conversion succeeded when another constraint forces MKV
+- audio policy: `audio_conform`
+- keep subtitle conversion intent while bringing audio into a delivery-conform shape when needed
 - details + flow: [Craigstreamy HEVC Smart Eng Sub Subtitle Convert Audio Conform Pack](profiles/packs/craigstreamy-hevc-smart-eng-sub-subtitle-convert-audio-conform.md)
 
 ## Craigstreamy HEVC Selected English Subtitle Preserve
@@ -237,40 +237,14 @@ Focus:
 
 - practical HEVC bitrate reduction approach
 - preserve audio streams
-- subtitle policy: `smart_eng_sub` + `preserve`
+- preserve one selected English subtitle when it appears intent-oriented
 - emit MKV when subtitle intent applies, otherwise stream-ready MP4 (fragmented + init/moov at start by default)
 - prioritize viewing-experience intent over single-container uniformity
 - guardrails: 1080 lane is SDR-only (`bt709`) in 1280x720..1920x1080, 4K lane accepts SDR/HDR in 1920x1080..3840x2160, legacy sub-HD lane is 320x240..1279x719 with broad codec/color intake
 
 Included active profiles:
 
-- `Craigstreamy HEVC Selected English Subtitle Preserve 4K`
-- `Craigstreamy HEVC Selected English Subtitle Preserve 1080p`
-- `Craigstreamy HEVC Selected English Subtitle Preserve Legacy Sub-HD`
-- these map to legacy internal profile ids for compatibility, but the docs surface stays canonical `craigstreamy`
+- `netflixy_preserve_audio_main_subtitle_intent_4k`
+- `netflixy_preserve_audio_main_subtitle_intent_1080p`
+- `netflixy_preserve_audio_main_subtitle_intent_legacy_subhd`
 - details + flow: [Craigstreamy HEVC Selected English Subtitle Preserve Pack](profiles/packs/craigstreamy-hevc-selected-english-subtitle-preserve.md)
-
-## Device Targets Open Audio
-
-Legacy compatibility pack.
-
-Pack id: `device_targets_open_audio`
-
-Focus:
-
-- older umbrella of device-shaped starter profiles
-- compatibility-first output envelopes
-- open audio stream preservation strategy where possible
-- superseded for day-to-day use by the explicit family/device packs above
-- details + flow: [Device Targets Open Audio Pack](profiles/packs/device-targets-open-audio.md)
-
-## Balanced Open Audio
-
-Pack id: `balanced_open_audio`
-
-Focus:
-
-- simple balanced 4K, 1080p, and legacy sub-HD lanes
-- easy starting point before device-specific tuning
-- strong baseline when you want predictable outputs with minimal profile complexity
-- details + flow: [Balanced Open Audio Pack](profiles/packs/balanced-open-audio.md)


### PR DESCRIPTION
Add a discussion-draft docs page showing how the current stock profile packs could be represented as one YAML file per pack.

This keeps `vfo_config.conf` as the runtime bridge for now, but sketches a clearer declarative shape for future pack planning and compilation.

Includes:
- YAML examples for `balanced_open_audio`
- YAML examples for `device_targets_open_audio`
- YAML examples for `craigstreamy_hevc_selected_english_subtitle_preserve`
- nav and home-page links so the examples page is easy to discover

This is docs-only and intentionally does not change runtime behavior yet.