### PR TITLE
fix: harden VFO practice validation loop

### DIFF
--- a/services/vfo/actions/live_encode_tools.sh
+++ b/services/vfo/actions/live_encode_tools.sh
@@ -22,6 +22,30 @@ vfo_live_shell_quote() {
 }
 
 vfo_live_output_device() {
+  local live_output="${VFO_LIVE_OUTPUT:-auto}"
+  live_output="$(live_encode_lower_text "$live_output")"
+
+  case "$live_output" in
+    stderr|pipe|log)
+      printf '%s' stderr
+      return 0
+      ;;
+    tty)
+      if [ -w /dev/tty ] 2>/dev/null; then
+        printf '%s' /dev/tty
+        return 0
+      fi
+      printf '%s' stderr
+      return 0
+      ;;
+    auto|"")
+      ;;
+    *)
+      printf '%s' stderr
+      return 0
+      ;;
+  esac
+
   if tty -s >/dev/null 2>&1 && [ -w /dev/tty ] 2>/dev/null; then
     printf '%s' /dev/tty
     return 0

--- a/services/vfo/actions/transcode_hevc_1080_main_subtitle_preserve_profile.sh
+++ b/services/vfo/actions/transcode_hevc_1080_main_subtitle_preserve_profile.sh
@@ -56,6 +56,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/subtitle_policy_tools.sh"
 # shellcheck source=quality_mode_tools.sh
 . "$SCRIPT_DIR/quality_mode_tools.sh"
+# shellcheck source=profile_test_tools.sh
+. "$SCRIPT_DIR/profile_test_tools.sh"
 
 ENCODER_MODE="${VFO_ENCODER_MODE:-auto}" # auto|hw|cpu
 INCLUDE_DEFAULT_MAIN_SUB="${VFO_MAIN_SUBTITLE_INCLUDE_DEFAULT:-0}"
@@ -70,6 +72,19 @@ CPU_PRESET="${CPU_PRESET:-slow}"
 VFO_DYNAMIC_METADATA_REPAIR="${VFO_DYNAMIC_METADATA_REPAIR:-1}"
 VFO_DYNAMIC_RANGE_STRICT="${VFO_DYNAMIC_RANGE_STRICT:-1}"
 VFO_DYNAMIC_RANGE_REPORT="${VFO_DYNAMIC_RANGE_REPORT:-1}"
+
+SOURCE_INPUT="$INPUT"
+
+workdir="$(vfo_drive_backed_tmpdir "$OUTPUT")"
+trap 'rm -rf "$workdir"' EXIT
+
+INPUT="$(profile_test_prepare_input "$SOURCE_INPUT" "$workdir")" || {
+  echo "Failed to prepare a smoke-test input trim" >&2
+  exit 1
+}
+if profile_test_is_enabled && [ "$INPUT" != "$SOURCE_INPUT" ]; then
+  echo "PROFILE TEST: using a shortened input segment for faster validation"
+fi
 
 has_videotoolbox_encoder() {
   ffmpeg -hide_banner -encoders 2>/dev/null | grep -q "hevc_videotoolbox"
@@ -166,9 +181,6 @@ using_hw=0
 if [ "$ENCODER_MODE" = "hw" ] || { [ "$ENCODER_MODE" = "auto" ] && has_videotoolbox_encoder; }; then
   using_hw=1
 fi
-
-workdir="$(vfo_drive_backed_tmpdir "$OUTPUT")"
-trap 'rm -rf "$workdir"' EXIT
 
 video_work_output="${workdir}/enc_video.mp4"
 

--- a/services/vfo/actions/transcode_hevc_legacy_main_subtitle_preserve_profile.sh
+++ b/services/vfo/actions/transcode_hevc_legacy_main_subtitle_preserve_profile.sh
@@ -67,6 +67,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/subtitle_policy_tools.sh"
 # shellcheck source=quality_mode_tools.sh
 . "$SCRIPT_DIR/quality_mode_tools.sh"
+# shellcheck source=profile_test_tools.sh
+. "$SCRIPT_DIR/profile_test_tools.sh"
 
 ENCODER_MODE="${VFO_ENCODER_MODE:-auto}" # auto|hw|cpu
 INCLUDE_DEFAULT_MAIN_SUB="${VFO_MAIN_SUBTITLE_INCLUDE_DEFAULT:-0}"
@@ -301,6 +303,19 @@ join_filters() {
   fi
 }
 
+SOURCE_INPUT="$INPUT"
+
+workdir="$(vfo_drive_backed_tmpdir "$OUTPUT")"
+trap 'rm -rf "$workdir"' EXIT
+
+INPUT="$(profile_test_prepare_input "$SOURCE_INPUT" "$workdir")" || {
+  echo "Failed to prepare a smoke-test input trim" >&2
+  exit 1
+}
+if profile_test_is_enabled && [ "$INPUT" != "$SOURCE_INPUT" ]; then
+  echo "PROFILE TEST: using a shortened input segment for faster validation"
+fi
+
 if ! subtitle_policy_resolve_plan "$INPUT" "$INCLUDE_DEFAULT_MAIN_SUB"; then
   echo "Subtitle policy resolution failed: ${SUBTITLE_POLICY_ERROR:-unknown subtitle policy error}"
   exit 1
@@ -365,9 +380,6 @@ using_hw=0
 if [ "$ENCODER_MODE" = "hw" ] || { [ "$ENCODER_MODE" = "auto" ] && has_videotoolbox_encoder; }; then
   using_hw=1
 fi
-
-workdir="$(vfo_drive_backed_tmpdir "$OUTPUT")"
-trap 'rm -rf "$workdir"' EXIT
 
 video_work_output="${workdir}/enc_video.mp4"
 

--- a/services/vfo/src/Config/config.c
+++ b/services/vfo/src/Config/config.c
@@ -348,7 +348,7 @@ config_t* con_init(const char *config_dir, char **revised_argv, int revised_argc
   bool activate_uw_work = false;
   char *pre_approved_words[] = {"vfo", "mezzanine", "source", "revert", "wipe", "profiles", "run", "auto", "doctor", "wizard", "show", "status", "status-json", "visualize", "mezzanine-clean", "profile", "-o", "--open"};
   int pre_array_length = (sizeof pre_approved_words / sizeof(char*));
-  for(int i = 0; i < revised_argc; i++) {
+  for(int i = 1; i < revised_argc; i++) {
     bool pre_approved_word_found = false;
     for(int j = 0; j < pre_array_length; j++) {
       if (strcmp(revised_argv[i], pre_approved_words[j]) == 0) {

--- a/services/vfo/src/Utils/utils.c
+++ b/services/vfo/src/Utils/utils.c
@@ -54,6 +54,23 @@ typedef struct utils_folder_entry_scan {
   bool has_visible_dir;
 } utils_folder_entry_scan_t;
 
+static bool utils_directory_is_ignored_hidden_folder(char *folder_name) {
+  if(folder_name == NULL || folder_name[0] == '\0')
+    return true;
+
+  if(utils_directory_is_current_or_parent(folder_name))
+    return true;
+
+  return folder_name[0] == '.';
+}
+
+static bool utils_file_is_prepared_dv_p81_variant(char *file_name) {
+  if(file_name == NULL)
+    return false;
+
+  return strstr(file_name, ".dv_p8.1.") != NULL;
+}
+
 static void utils_scan_visible_entries(char *folder, utils_folder_entry_scan_t *scan) {
   DIR *directory = NULL;
   struct dirent *entry = NULL;
@@ -71,7 +88,8 @@ static void utils_scan_visible_entries(char *folder, utils_folder_entry_scan_t *
   }
 
   while((entry = readdir(directory)) != NULL) {
-    if(utils_directory_is_current_or_parent(entry->d_name) || utils_file_is_macos_hidden_files(entry->d_name))
+    if((entry->d_type == DT_DIR && utils_directory_is_ignored_hidden_folder(entry->d_name))
+       || (entry->d_type == DT_REG && utils_file_is_macos_hidden_files(entry->d_name)))
       continue;
 
     if(entry->d_type == DT_REG)
@@ -112,7 +130,7 @@ static void utils_populate_active_tv_descendants(active_tv_f_node_t *top_level_t
     if(directory4 == NULL)
       printf("MAJOR ERROR: vfo could not open %s\n", tmp_active_tv_head->from_tv_f_folder);
     while((entry4 = readdir(directory4)) != NULL) {
-      if(entry4->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry4->d_name))) {
+      if(entry4->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry4->d_name))) {
         char *from_tv_f_folder2 = utils_combine_to_full_path(tmp_active_tv_head->from_tv_f_folder, entry4->d_name);
         char *to_tv_f_folder2 = utils_combine_to_full_path(tmp_active_tv_head->to_tv_f_folder, entry4->d_name);
         int this_layer_is2 = 2;
@@ -132,7 +150,7 @@ static void utils_populate_active_tv_descendants(active_tv_f_node_t *top_level_t
         if(directory5 == NULL)
           printf("MAJOR ERROR: vfo could not open %s\n", tmp_SECOND_LEVEL_active_tv_head->from_tv_f_folder);
         while((entry5 = readdir(directory5)) != NULL) {
-          if(entry5->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry5->d_name))) {
+          if(entry5->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry5->d_name))) {
             char *from_tv_f_folder3 = utils_combine_to_full_path(tmp_SECOND_LEVEL_active_tv_head->from_tv_f_folder, entry5->d_name);
             char *to_tv_f_folder3 = utils_combine_to_full_path(tmp_SECOND_LEVEL_active_tv_head->to_tv_f_folder, entry5->d_name);
             int this_layer_is3 = 3;
@@ -623,21 +641,23 @@ char *utils_fetch_single_file_name(char *folder) {
     printf("Could not open directory to fetch single file name in: %s\n", folder);
     exit(EXIT_FAILURE);
   }
-  char *tmp_file_name;
-  char *for_return;
+  char tmp_file_name[BUFSIZ] = "";
+  char *for_return = NULL;
   bool file_found = false;
   while((entry=readdir(directory)) != NULL) {  
     if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
       file_found = true;
-      tmp_file_name = entry->d_name;
-      break;
+      strcpy(tmp_file_name, entry->d_name);
+      if(utils_file_is_prepared_dv_p81_variant(entry->d_name))
+        break;
     }
   }
   if(closedir(directory) == -1) {
     printf("Error closing directory: %s\n", folder);
   }
   if(file_found == true) {
-    for_return = tmp_file_name;
+    for_return = malloc(strlen(tmp_file_name) + 1);
+    strcpy(for_return, tmp_file_name);
     return for_return;
   } else if(file_found == false) {
     printf("bool false, could not fetch a file in %s to get get file name:\n", folder);
@@ -659,8 +679,8 @@ char* utils_fetch_single_file(char *folder) {
     printf("Could not open directory to find any file in: %s\n", folder);
     exit(EXIT_FAILURE);
   }
-  char *tmp_file_name;
-  char *for_return;
+  char tmp_file_name[BUFSIZ] = "";
+  char *for_return = NULL;
   bool file_found = false;
   while((entry=readdir(directory)) != NULL) {  
     if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
@@ -677,8 +697,9 @@ char* utils_fetch_single_file(char *folder) {
          utils_is_file_extension_mpeg(entry->d_name) ||
          utils_is_file_extension_vob(entry->d_name)) {
         file_found = true;
-        tmp_file_name = entry->d_name;
-        break;
+        strcpy(tmp_file_name, entry->d_name);
+        if(utils_file_is_prepared_dv_p81_variant(entry->d_name))
+          break;
       }
     }
   }
@@ -962,7 +983,7 @@ void utils_does_folder_contain_valid_custom_folders(char *folder, cf_node_t *cf_
       utils_found_a_rogue_file(entry->d_name, folder);
       exit(EXIT_FAILURE);
     } 
-    else if (entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name)) && !(cf_folder_name_exits(cf_head, entry->d_name))) {
+    else if (entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name)) && !(cf_folder_name_exits(cf_head, entry->d_name))) {
       printf("woah lad what's this\n");
       printf("%s is not a custom folder in %s\n", entry->d_name, folder);
       exit(EXIT_FAILURE);
@@ -996,7 +1017,7 @@ void utils_is_folder_missing_custom_folders(char *folder, cf_node_t *cf_ll_head)
       utils_found_a_rogue_file(entry->d_name, folder);
       exit(EXIT_FAILURE);
     } 
-    else if (entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name)) && cf_folder_name_exits(cf_ll_head, entry->d_name)) {
+    else if (entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name)) && cf_folder_name_exits(cf_ll_head, entry->d_name)) {
       counter++;
     }     
   }
@@ -1024,7 +1045,7 @@ void utils_are_custom_folders_type_compliant(char *root_folder, char* rf_rules, 
     exit(EXIT_FAILURE);
   }
   while ((entry = readdir(directory)) != NULL) {
-    if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+    if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
       //for each custom_folder dir
       //get their type
       char *ftype = cf_get_type_from_folder_name(cf_ll_head, entry->d_name);
@@ -1054,7 +1075,7 @@ void utils_are_custom_folders_type_compliant(char *root_folder, char* rf_rules, 
             utils_found_a_rogue_file(mixed_entry->d_name, tmp_cf_loc);
             exit(EXIT_FAILURE);
           }
-          if(mixed_entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(mixed_entry->d_name))) {
+          if(mixed_entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(mixed_entry->d_name))) {
             char *tmp_mixed_child = utils_combine_to_full_path(tmp_cf_loc, mixed_entry->d_name);
             int mixed_child_type = utils_detect_mixed_child_type(tmp_mixed_child);
             if(mixed_child_type == UTILS_MIXED_CHILD_FILM) {
@@ -1093,13 +1114,14 @@ void utils_is_custom_folder_tv_type_compliant(char *custom_folder, char *rf_rule
     exit(EXIT_FAILURE);
   }
   int movie_file_count = 0;
+  int prepared_variant_count = 0;
   while ((entry = readdir(directory)) != NULL) {
     if(strcmp(layer, "layer1") == 0 || strcmp(layer, "layer2") == 0 ||  strcmp(layer, "layer3") == 0) {
       if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
         utils_found_a_rogue_file(entry->d_name, custom_folder);
         exit(EXIT_FAILURE);
       }
-      if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+      if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
         char *tmp_cf_loc = utils_combine_to_full_path(custom_folder, entry->d_name);
         if (utils_is_folder_empty(tmp_cf_loc)) {
           printf("ERROR, %s is empty.  Please delete this folder\n", tmp_cf_loc);
@@ -1124,14 +1146,18 @@ void utils_is_custom_folder_tv_type_compliant(char *custom_folder, char *rf_rule
       if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
         utils_replace_spaces(entry->d_name , custom_folder);
         if (utils_is_file_extension_valid(entry->d_name, rf_rules)) {
-          movie_file_count++;
+          if(utils_file_is_prepared_dv_p81_variant(entry->d_name))
+            prepared_variant_count++;
+          else
+            movie_file_count++;
         }
       }
-      if(movie_file_count >= 2) {
+      int visible_movie_file_count = prepared_variant_count > 0 ? prepared_variant_count : movie_file_count;
+      if(visible_movie_file_count >= 2) {
         printf("looks like %s contains more than a single movie file!\n", custom_folder);
         exit(EXIT_FAILURE);
       }
-      if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+      if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
         char *tmp_cf_loc = utils_combine_to_full_path(custom_folder, entry->d_name);
         printf("woah lad, no folders should be present here in %s\n", tmp_cf_loc);
         exit(EXIT_FAILURE);
@@ -1185,13 +1211,14 @@ void utils_is_custom_folder_films_type_compliant(char *custom_folder, char *rf_r
     exit(EXIT_FAILURE);
   }
   int movie_file_count = 0;
+  int prepared_variant_count = 0;
   while ((entry = readdir(directory)) != NULL) {
     if(strcmp(layer, "layer1") == 0) {
       if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
           utils_found_a_rogue_file(entry->d_name, custom_folder);
           exit(EXIT_FAILURE);
       }
-      if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+      if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
         char *tmp_cf_loc = utils_combine_to_full_path(custom_folder, entry->d_name);
         if (utils_is_folder_empty(tmp_cf_loc)) {
           printf("ERROR, %s is empty.  Please delete this folder\n", tmp_cf_loc);
@@ -1205,10 +1232,13 @@ void utils_is_custom_folder_films_type_compliant(char *custom_folder, char *rf_r
       if(entry->d_type == DT_REG && !(utils_file_is_macos_hidden_files(entry->d_name))) {
         utils_replace_spaces(entry->d_name , custom_folder);
         if (utils_is_file_extension_valid(entry->d_name, rf_rules)) {
-            movie_file_count++;
+            if(utils_file_is_prepared_dv_p81_variant(entry->d_name))
+              prepared_variant_count++;
+            else
+              movie_file_count++;
         }
       }
-      if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+      if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
         char *tmp_cf_loc = utils_combine_to_full_path(custom_folder, entry->d_name);
         if (utils_is_folder_empty(tmp_cf_loc)) {
           printf("ERROR, %s is empty.  Please delete this folder\n", tmp_cf_loc);
@@ -1218,11 +1248,12 @@ void utils_is_custom_folder_films_type_compliant(char *custom_folder, char *rf_r
           exit(EXIT_FAILURE);
         }
       }
-      if(movie_file_count >= 2) {
+      int visible_movie_file_count = prepared_variant_count > 0 ? prepared_variant_count : movie_file_count;
+      if(visible_movie_file_count >= 2) {
         printf("looks like %s contains more than a single movie file!\n", custom_folder);
         exit(EXIT_FAILURE);
       }
-      if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+      if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
         char *tmp_cf_loc = utils_combine_to_full_path(custom_folder, entry->d_name);
         printf("woah lad, no folders should be present here in %s\n", tmp_cf_loc);
         exit(EXIT_FAILURE);
@@ -1510,7 +1541,7 @@ active_cf_node_t* utils_generate_from_to_ll(cf_node_t *cf_head, char *from_cf_pa
     printf("MAJOR ERROR: vfo could not open %s\n", from_cf_parent_folder);
   active_cf_node_t *active_cf_head = NULL;
   while((entry = readdir(directory)) != NULL) {
-    if(entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry->d_name))) {
+    if(entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry->d_name))) {
       char *tmp_current_custom_folder_type = cf_get_type_from_folder_name(cf_head, entry->d_name);
       char *from_cf_loc = utils_combine_to_full_path(from_cf_parent_folder, entry->d_name);
       char *to_cf_loc = utils_combine_to_full_path(to_cf_parent_folder, entry->d_name);
@@ -1535,7 +1566,7 @@ active_cf_node_t* utils_generate_from_to_ll(cf_node_t *cf_head, char *from_cf_pa
         if(directory2 == NULL)
           printf("MAJOR ERROR: vfo could not open %s\n", tmp_active_cf->from_cf_folder);
         while((entry2 = readdir(directory2)) != NULL) {
-          if(entry2->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry2->d_name))) {
+          if(entry2->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry2->d_name))) {
             char *from_films_f_folder = utils_combine_to_full_path(tmp_active_cf->from_cf_folder, entry2->d_name); 
             char *to_films_f_folder = utils_combine_to_full_path(tmp_active_cf->to_cf_folder, entry2->d_name);
             active_films_f_node_t *active_films_f_node = active_films_f_create_node(from_films_f_folder, to_films_f_folder);
@@ -1554,7 +1585,7 @@ active_cf_node_t* utils_generate_from_to_ll(cf_node_t *cf_head, char *from_cf_pa
         if(directory3 == NULL)
           printf("MAJOR ERROR: vfo could not open %s\n", tmp_active_cf->from_cf_folder);
         while((entry3 = readdir(directory3)) != NULL) {
-          if(entry3->d_type == DT_DIR && !(utils_directory_is_current_or_parent(entry3->d_name))) {
+          if(entry3->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(entry3->d_name))) {
             char *from_tv_f_folder = utils_combine_to_full_path(tmp_active_cf->from_cf_folder, entry3->d_name); 
             char *to_tv_f_folder = utils_combine_to_full_path(tmp_active_cf->to_cf_folder, entry3->d_name);
             int this_layer_is = 1;
@@ -1573,7 +1604,7 @@ active_cf_node_t* utils_generate_from_to_ll(cf_node_t *cf_head, char *from_cf_pa
         if(mixed_directory == NULL)
           printf("MAJOR ERROR: vfo could not open %s\n", tmp_active_cf->from_cf_folder);
         while((mixed_entry = readdir(mixed_directory)) != NULL) {
-          if(mixed_entry->d_type == DT_DIR && !(utils_directory_is_current_or_parent(mixed_entry->d_name))) {
+          if(mixed_entry->d_type == DT_DIR && !(utils_directory_is_ignored_hidden_folder(mixed_entry->d_name))) {
             char *from_child_folder = utils_combine_to_full_path(tmp_active_cf->from_cf_folder, mixed_entry->d_name);
             char *to_child_folder = utils_combine_to_full_path(tmp_active_cf->to_cf_folder, mixed_entry->d_name);
             int child_type = utils_detect_mixed_child_type(from_child_folder);
@@ -1820,6 +1851,7 @@ unsigned long long utils_fetch_single_file_size_bytes(char *folder) {
   DIR *directory = NULL;
   struct dirent *entry = NULL;
   unsigned long long size_bytes = 0ULL;
+  unsigned long long fallback_size_bytes = 0ULL;
 
   directory = opendir(folder);
   if(directory == NULL)
@@ -1843,14 +1875,21 @@ unsigned long long utils_fetch_single_file_size_bytes(char *folder) {
       }
       if(valid_ext) {
         char *full_path = utils_combine_to_full_path(folder, entry->d_name);
-        size_bytes = utils_get_single_file_size_bytes(full_path);
+        unsigned long long entry_size_bytes = utils_get_single_file_size_bytes(full_path);
         free(full_path);
-        break;
+        if(utils_file_is_prepared_dv_p81_variant(entry->d_name)) {
+          size_bytes = entry_size_bytes;
+          break;
+        }
+        if(fallback_size_bytes == 0ULL)
+          fallback_size_bytes = entry_size_bytes;
       }
     }
   }
 
   closedir(directory);
+  if(size_bytes == 0ULL)
+    size_bytes = fallback_size_bytes;
   return size_bytes;
 }
 

--- a/services/vfo/test/UtilsTests/u_tests.c
+++ b/services/vfo/test/UtilsTests/u_tests.c
@@ -193,3 +193,91 @@ void test_utils_are_custom_folders_type_compliant_accepts_mixed_library(void **s
   free(movie_folder);
   free(mixed_root);
 }
+
+void test_utils_are_custom_folders_type_compliant_ignores_hidden_transient_dirs(void **state) {
+  char root_template[] = "/tmp/vfo-hidden-transient-XXXXXX";
+  char *root = mkdtemp(root_template);
+  char *movies_root = NULL;
+  char *movie_folder = NULL;
+  char *movie_file = NULL;
+  char *hidden_tmp = NULL;
+  char *hidden_tmp_file = NULL;
+  char *allowed_types[] = {"films", "tv", "mixed"};
+  char conf[] = "CUSTOM_FOLDER=\"Movies,films\"\n";
+  cf_node_t *cf_head = NULL;
+
+  (void)state;
+  assert_non_null(root);
+
+  movies_root = utils_combine_to_full_path(root, "Movies");
+  movie_folder = utils_combine_to_full_path(movies_root, "MovieOne");
+  movie_file = utils_combine_to_full_path(movie_folder, "MovieOne.mkv");
+  hidden_tmp = utils_combine_to_full_path(movie_folder, ".MovieOne.dvp81.tmp");
+  hidden_tmp_file = utils_combine_to_full_path(hidden_tmp, "scratch.hevc");
+
+  utils_create_folder(movies_root);
+  utils_create_folder(movie_folder);
+  utils_create_folder(hidden_tmp);
+  u_write_file(movie_file);
+  u_write_file(hidden_tmp_file);
+
+  cf_head = con_extract_to_cf_ll(conf, "CUSTOM_FOLDER=", allowed_types, 3, cf_head);
+  utils_are_custom_folders_type_compliant(root, "mkv_original", cf_head);
+
+  unlink(hidden_tmp_file);
+  unlink(movie_file);
+  rmdir(hidden_tmp);
+  rmdir(movie_folder);
+  rmdir(movies_root);
+  rmdir(root);
+
+  free(hidden_tmp_file);
+  free(hidden_tmp);
+  free(movie_file);
+  free(movie_folder);
+  free(movies_root);
+}
+
+void test_utils_prepared_dv_p81_variant_is_preferred_single_movie_file(void **state) {
+  char root_template[] = "/tmp/vfo-dv-p81-prepared-XXXXXX";
+  char *root = mkdtemp(root_template);
+  char *movies_root = NULL;
+  char *movie_folder = NULL;
+  char *movie_file = NULL;
+  char *prepared_file = NULL;
+  char *selected_file = NULL;
+  char *allowed_types[] = {"films", "tv", "mixed"};
+  char conf[] = "CUSTOM_FOLDER=\"Movies,films\"\n";
+  cf_node_t *cf_head = NULL;
+
+  (void)state;
+  assert_non_null(root);
+
+  movies_root = utils_combine_to_full_path(root, "Movies");
+  movie_folder = utils_combine_to_full_path(movies_root, "MovieOne");
+  movie_file = utils_combine_to_full_path(movie_folder, "MovieOne.mkv");
+  prepared_file = utils_combine_to_full_path(movie_folder, "MovieOne.dv_p8.1.mkv");
+
+  utils_create_folder(movies_root);
+  utils_create_folder(movie_folder);
+  u_write_file(movie_file);
+  u_write_file(prepared_file);
+
+  cf_head = con_extract_to_cf_ll(conf, "CUSTOM_FOLDER=", allowed_types, 3, cf_head);
+  utils_are_custom_folders_type_compliant(root, "mkv_original", cf_head);
+
+  selected_file = utils_fetch_single_file(movie_folder);
+  assert_non_null(strstr(selected_file, ".dv_p8.1.mkv"));
+
+  free(selected_file);
+  unlink(prepared_file);
+  unlink(movie_file);
+  rmdir(movie_folder);
+  rmdir(movies_root);
+  rmdir(root);
+
+  free(prepared_file);
+  free(movie_file);
+  free(movie_folder);
+  free(movies_root);
+}

--- a/services/vfo/test/UtilsTests/u_tests.h
+++ b/services/vfo/test/UtilsTests/u_tests.h
@@ -39,5 +39,7 @@ void test_utils_is_file_extension_ts(void **state);
 void test_utils_is_file_extension_valid_supports_ts_original(void **state);
 void test_utils_is_file_extension_valid_supports_extended_mezzanine_inputs(void **state);
 void test_utils_are_custom_folders_type_compliant_accepts_mixed_library(void **state);
+void test_utils_are_custom_folders_type_compliant_ignores_hidden_transient_dirs(void **state);
+void test_utils_prepared_dv_p81_variant_is_preferred_single_movie_file(void **state);
 
 #endif // U_TESTS_H

--- a/services/vfo/test/main.c
+++ b/services/vfo/test/main.c
@@ -83,6 +83,8 @@ int main(void) {
         cmocka_unit_test(test_utils_is_file_extension_valid_supports_ts_original),
         cmocka_unit_test(test_utils_is_file_extension_valid_supports_extended_mezzanine_inputs),
         cmocka_unit_test(test_utils_are_custom_folders_type_compliant_accepts_mixed_library),
+        cmocka_unit_test(test_utils_are_custom_folders_type_compliant_ignores_hidden_transient_dirs),
+        cmocka_unit_test(test_utils_prepared_dv_p81_variant_is_preferred_single_movie_file),
         /* Config */
         cmocka_unit_test(test_con_init_config_dir_null_ptr),
         cmocka_unit_test(test_con_init_config_dir_empty_str),

--- a/tests/e2e/run_vfo_practice_validation_loop.sh
+++ b/tests/e2e/run_vfo_practice_validation_loop.sh
@@ -7,7 +7,13 @@ PRACTICE_ROOT="${VFO_PRACTICE_ROOT:-/Volumes/Mitchum/vfo_practice}"
 SELECTED_ASSET="${VFO_PRACTICE_ASSET:-}"
 PROFILE_PACK="${VFO_PRACTICE_PROFILE_PACK:-craigstreamy_hevc_smart_eng_sub_aggressive_vmaf}"
 VFO_BIN="${VFO_PRACTICE_VFO_BIN:-vfo}"
-PROFILE_COMMAND="${VFO_PRACTICE_PROFILE_COMMAND:-${VFO_BIN} run}"
+VFO_PATH_PREFIX=""
+VFO_COMMAND_NAME="$VFO_BIN"
+if [[ "$VFO_BIN" == */* ]]; then
+  VFO_PATH_PREFIX="$(cd "$(dirname "$VFO_BIN")" && pwd)"
+  VFO_COMMAND_NAME="$(basename "$VFO_BIN")"
+fi
+PROFILE_COMMAND="${VFO_PRACTICE_PROFILE_COMMAND:-${VFO_COMMAND_NAME} run}"
 REPORT_ROOT="${VFO_PRACTICE_REPORT_ROOT:-${ROOT_DIR}/tests/e2e/.reports/vfo-practice}"
 POLL_SECONDS="${VFO_PRACTICE_POLL_SECONDS:-21600}"
 CREATE_ISSUES="${VFO_PRACTICE_CREATE_ISSUES:-0}"
@@ -196,10 +202,10 @@ run_with_log() {
       SOURCE_TEST_ACTIVE="$SOURCE_TEST_ACTIVE_VALUE" \
       SOURCE_TEST_TRIM_START="$SOURCE_TEST_TRIM_START_VALUE" \
       SOURCE_TEST_TRIM_DURATION="$SOURCE_TEST_TRIM_DURATION_VALUE" \
+      PATH="${VFO_PATH_PREFIX:+${VFO_PATH_PREFIX}:}$PATH" \
       bash -o pipefail -lc "$command_text"
   ) 2>&1 | tee "$log_file"
   status="${PIPESTATUS[0]}"
-  set -e
   printf '%s\n' "$status" > "$status_file"
   log "END ${stage}: exit=${status}"
   return "$status"
@@ -366,7 +372,7 @@ analyze_run() {
   status_status="$(cat "${run_dir}/status.log.status" 2>/dev/null || printf '0')"
   profile_status="$(cat "${run_dir}/profile.log.status" 2>/dev/null || printf '0')"
 
-  fatal_pattern='MAJOR ERROR|RUN ERROR|PROFILE .*WARNING: .*failed|WARNING: all destination locations were exhausted|Source contains Dolby Vision .*conversion failed|ffmpeg command failed|Conversion failed|Error opening output|Could not write header|No space left on device|Cannot write moov atom|Invalid argument|syntax error|command not found|Segmentation fault|QUALITY .*ERROR|quality stage failed'
+  fatal_pattern='MAJOR ERROR|RUN ERROR|PROFILE .*WARNING: .*failed|WARNING: all destination locations were exhausted|Source contains Dolby Vision .*conversion failed|ffmpeg command failed|Conversion failed|Error opening output|Could not write header|No space left on device|Cannot write moov atom|Invalid argument|syntax error|command not found|Segmentation fault|QUALITY .*ERROR|quality stage failed|NOT a valid profile|ERROR - detected one or more unknown words'
   weak_pattern='WARN:|WARNING:|Abort trap|fallback|deprecated|Last message repeated'
 
   first_error="$(first_matching_line "$fatal_pattern" "${run_dir}/doctor.log" "${run_dir}/status.log" "${run_dir}/profile.log" || true)"
@@ -376,12 +382,12 @@ analyze_run() {
   command_text="$PROFILE_COMMAND"
   if [ "$doctor_status" != "0" ]; then
     stage="doctor"
-    command_text="${VFO_BIN} doctor"
-    first_error="${first_error:-${VFO_BIN} doctor exited ${doctor_status}}"
+    command_text="${VFO_COMMAND_NAME} doctor"
+    first_error="${first_error:-${VFO_COMMAND_NAME} doctor exited ${doctor_status}}"
   elif [ "$status_status" != "0" ]; then
     stage="status"
-    command_text="${VFO_BIN} status"
-    first_error="${first_error:-${VFO_BIN} status exited ${status_status}}"
+    command_text="${VFO_COMMAND_NAME} status"
+    first_error="${first_error:-${VFO_COMMAND_NAME} status exited ${status_status}}"
   elif [ "$profile_status" != "0" ]; then
     stage="profile"
     command_text="$PROFILE_COMMAND"
@@ -453,6 +459,8 @@ run_cycle() {
     echo "selected_or_newest_asset=${asset}"
     echo "profile_pack=${PROFILE_PACK}"
     echo "vfo_bin=${VFO_BIN}"
+    echo "vfo_command_name=${VFO_COMMAND_NAME}"
+    echo "vfo_path_prefix=${VFO_PATH_PREFIX}"
     echo "profile_command=${PROFILE_COMMAND}"
     echo "source_test_active=${SOURCE_TEST_ACTIVE_VALUE}"
     echo "source_test_trim_start=${SOURCE_TEST_TRIM_START_VALUE}"
@@ -465,9 +473,9 @@ run_cycle() {
   log "Smoke trim: SOURCE_TEST_ACTIVE=${SOURCE_TEST_ACTIVE_VALUE} SOURCE_TEST_TRIM_DURATION=${SOURCE_TEST_TRIM_DURATION_VALUE}"
 
   set +e
-  run_with_log "doctor" "${VFO_BIN} doctor" "${run_dir}/doctor.log"
+  run_with_log "doctor" "${VFO_COMMAND_NAME} doctor" "${run_dir}/doctor.log"
   doctor_status="$?"
-  run_with_log "status" "${VFO_BIN} status" "${run_dir}/status.log"
+  run_with_log "status" "${VFO_COMMAND_NAME} status" "${run_dir}/status.log"
   status_status="$?"
   if [ "$doctor_status" = "0" ] && [ "$status_status" = "0" ]; then
     run_with_log "profile" "$PROFILE_COMMAND" "${run_dir}/profile.log"

--- a/tests/e2e/run_vfo_practice_validation_loop.sh
+++ b/tests/e2e/run_vfo_practice_validation_loop.sh
@@ -13,6 +13,7 @@ if [[ "$VFO_BIN" == */* ]]; then
   VFO_PATH_PREFIX="$(cd "$(dirname "$VFO_BIN")" && pwd)"
   VFO_COMMAND_NAME="$(basename "$VFO_BIN")"
 fi
+VFO_ACTIONS_PATH_PREFIX="${VFO_PRACTICE_ACTIONS_DIR:-${ROOT_DIR}/services/vfo/actions}"
 PROFILE_COMMAND="${VFO_PRACTICE_PROFILE_COMMAND:-${VFO_COMMAND_NAME} run}"
 REPORT_ROOT="${VFO_PRACTICE_REPORT_ROOT:-${ROOT_DIR}/tests/e2e/.reports/vfo-practice}"
 POLL_SECONDS="${VFO_PRACTICE_POLL_SECONDS:-21600}"
@@ -23,6 +24,8 @@ GITHUB_REPO="${VFO_PRACTICE_GITHUB_REPO:-CraigWatt/vfo}"
 SOURCE_TEST_ACTIVE_VALUE="${SOURCE_TEST_ACTIVE:-true}"
 SOURCE_TEST_TRIM_START_VALUE="${SOURCE_TEST_TRIM_START:-00:00:00}"
 SOURCE_TEST_TRIM_DURATION_VALUE="${SOURCE_TEST_TRIM_DURATION:-00:02:00}"
+VFO_ASSUME_YES_VALUE="${VFO_ASSUME_YES:-1}"
+VFO_LIVE_OUTPUT_VALUE="${VFO_LIVE_OUTPUT:-stderr}"
 
 MODE="once"
 LAST_FINGERPRINT=""
@@ -44,10 +47,13 @@ Options:
 Useful environment:
   VFO_PRACTICE_CREATE_ISSUES=1
   VFO_PRACTICE_VFO_BIN=/usr/local/bin/vfo
+  VFO_PRACTICE_ACTIONS_DIR=/Users/craigwatt/localProjects/vfo/services/vfo/actions
   VFO_PRACTICE_PROFILE_COMMAND="vfo run"
   VFO_PRACTICE_PROFILE_COMMAND="yes y | vfo profiles"
   SOURCE_TEST_ACTIVE=true
   SOURCE_TEST_TRIM_DURATION=00:02:00
+  VFO_ASSUME_YES=1
+  VFO_LIVE_OUTPUT=stderr
 
 Reports:
   tests/e2e/.reports/vfo-practice/latest
@@ -202,8 +208,10 @@ run_with_log() {
       SOURCE_TEST_ACTIVE="$SOURCE_TEST_ACTIVE_VALUE" \
       SOURCE_TEST_TRIM_START="$SOURCE_TEST_TRIM_START_VALUE" \
       SOURCE_TEST_TRIM_DURATION="$SOURCE_TEST_TRIM_DURATION_VALUE" \
-      PATH="${VFO_PATH_PREFIX:+${VFO_PATH_PREFIX}:}$PATH" \
-      bash -o pipefail -lc "$command_text"
+      VFO_ASSUME_YES="$VFO_ASSUME_YES_VALUE" \
+      VFO_LIVE_OUTPUT="$VFO_LIVE_OUTPUT_VALUE" \
+      PATH="${VFO_ACTIONS_PATH_PREFIX:+${VFO_ACTIONS_PATH_PREFIX}:}${VFO_PATH_PREFIX:+${VFO_PATH_PREFIX}:}$PATH" \
+      bash -o pipefail -c "$command_text"
   ) 2>&1 | tee "$log_file"
   status="${PIPESTATUS[0]}"
   printf '%s\n' "$status" > "$status_file"
@@ -372,7 +380,7 @@ analyze_run() {
   status_status="$(cat "${run_dir}/status.log.status" 2>/dev/null || printf '0')"
   profile_status="$(cat "${run_dir}/profile.log.status" 2>/dev/null || printf '0')"
 
-  fatal_pattern='MAJOR ERROR|RUN ERROR|PROFILE .*WARNING: .*failed|WARNING: all destination locations were exhausted|Source contains Dolby Vision .*conversion failed|ffmpeg command failed|Conversion failed|Error opening output|Could not write header|No space left on device|Cannot write moov atom|Invalid argument|syntax error|command not found|Segmentation fault|QUALITY .*ERROR|quality stage failed|NOT a valid profile|ERROR - detected one or more unknown words'
+  fatal_pattern='MAJOR ERROR|RUN ERROR|PROFILE .*WARNING: .*failed|WARNING: all destination locations were exhausted|Source contains Dolby Vision .*conversion failed|ffmpeg command failed|Conversion failed|Error opening output|Could not write header|No space left on device|Cannot write moov atom|Invalid argument|syntax error|command not found|Segmentation fault|QUALITY ERROR:|quality stage failed|NOT a valid profile|ERROR - detected one or more unknown words'
   weak_pattern='WARN:|WARNING:|Abort trap|fallback|deprecated|Last message repeated'
 
   first_error="$(first_matching_line "$fatal_pattern" "${run_dir}/doctor.log" "${run_dir}/status.log" "${run_dir}/profile.log" || true)"
@@ -461,6 +469,7 @@ run_cycle() {
     echo "vfo_bin=${VFO_BIN}"
     echo "vfo_command_name=${VFO_COMMAND_NAME}"
     echo "vfo_path_prefix=${VFO_PATH_PREFIX}"
+    echo "vfo_actions_path_prefix=${VFO_ACTIONS_PATH_PREFIX}"
     echo "profile_command=${PROFILE_COMMAND}"
     echo "source_test_active=${SOURCE_TEST_ACTIVE_VALUE}"
     echo "source_test_trim_start=${SOURCE_TEST_TRIM_START_VALUE}"
@@ -470,6 +479,7 @@ run_cycle() {
   log "Report directory: ${run_dir}"
   log "Context asset: ${asset}"
   log "Profile command: ${PROFILE_COMMAND}"
+  log "Actions path: ${VFO_ACTIONS_PATH_PREFIX}"
   log "Smoke trim: SOURCE_TEST_ACTIVE=${SOURCE_TEST_ACTIVE_VALUE} SOURCE_TEST_TRIM_DURATION=${SOURCE_TEST_TRIM_DURATION_VALUE}"
 
   set +e


### PR DESCRIPTION
## Summary

- Skip `argv[0]` during config unknown-word validation so absolute binary paths such as `/usr/local/bin/vfo doctor` are not treated as profile names.
- Normalize absolute `VFO_PRACTICE_VFO_BIN` values in the practice validation runner by prepending the binary directory to `PATH` and invoking the basename.
- Run the practice loop noninteractively by default with `VFO_ASSUME_YES=1`, and keep local repo action scripts ahead of installed scripts during validation.
- Capture live child-process output in practice reports with `VFO_LIVE_OUTPUT=stderr` while preserving the normal terminal-live default outside the runner.
- Ignore dot-prefixed transient mezzanine directories and prefer prepared `.dv_p8.1.mkv` variants when a source folder contains both the original MKV and prepared DV P8.1 output.
- Apply smoke-test input trimming to the 1080p and legacy main-subtitle profile scripts, matching the existing 4K behavior.
- Tighten fatal-pattern detection so successful `QUALITY SUMMARY ... metric_errors=0` lines do not become false-positive failures.

Closes #175

## Verification

- `bash -n tests/e2e/run_vfo_practice_validation_loop.sh services/vfo/actions/live_encode_tools.sh services/vfo/actions/transcode_hevc_1080_main_subtitle_preserve_profile.sh services/vfo/actions/transcode_hevc_legacy_main_subtitle_preserve_profile.sh services/vfo/actions/transcode_hevc_4k_main_subtitle_preserve_profile.sh`
- `git diff --check`
- `make tests` (50 passed)
- `make all`
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin SOURCE_TEST_ACTIVE=true SOURCE_TEST_TRIM_DURATION=00:02:00 VFO_PRACTICE_VFO_BIN=/Users/craigwatt/localProjects/vfo/services/vfo/bin/vfo tests/e2e/run_vfo_practice_validation_loop.sh --once`
  - `doctor` passed.
  - `status` passed.
  - `vfo run` completed noninteractively.
  - Runner ended with `No issue-worthy findings detected`.

## Notes

No media content summary is included. Practice-bed paths are used only as technical validation context.